### PR TITLE
Fix FILE option filter bug

### DIFF
--- a/examples/browser-test.html
+++ b/examples/browser-test.html
@@ -41,7 +41,7 @@
 			    });
 
 			    // Handle the --include-file switch
-			    parser.on('include-file', function(value) {
+			    parser.on('include-file', function(name, value) {
 			        options.files.push(value);
 			    });
 


### PR DESCRIPTION
The original demo file only `push()` the name of flag into the `options.files` instead of the file name.